### PR TITLE
Change log location

### DIFF
--- a/.ebextensions/cloud-log-init.config
+++ b/.ebextensions/cloud-log-init.config
@@ -1,0 +1,7 @@
+files:
+  "/opt/elasticbeanstalk/tasks/taillogs.d/cloud-init.conf" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      /var/log/nodejs/cognicity-server.log

--- a/.ebextensions/cloud-log-init.config
+++ b/.ebextensions/cloud-log-init.config
@@ -4,4 +4,4 @@ files:
     owner: root
     group: root
     content: |
-      /var/log/nodejs/cognicity-server.log
+      /var/app/current/cognicity-server.log

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ You can then run `grunt` if you need to rebuild the build products following cha
 
 ### Configuration
 Server configuration parameters are stored in a configuration file which is parsed by server.js. See config.js for an example configuration. It is possible to run multiple server instances using different configuration files so long as a unique port is assigned to each instance.
-* compression - If true, enable Express compression middleware to gzip responses
+Some that you probably want to change:
+* config.pg.conString - the database connection string that can include username and password as well as the hostname and database name. If you're deploying to [AWS Elastic Beanstalk](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/Welcome.html) you will need to configure a property with name DB_NAME and value set to the database name, under Configuration -> Software configuration.
+* config.compression - If true, enable Express compression middleware to gzip responses. If deploying standalone then you probably want to set this to true. If deploying behind a reverse proxy+cache like [nginx](http://nginx.org) then you will want to leave this config option set to false and enable compressing using the caching server. For Elastic Beanstalk using nginx this is configured automatically using the Elastic Beanstalk [config file](https://github.com/smart-facility/cognicity-server/blob/master/.ebextensions/nginx.config) (note if deploying standalone then this file actually contains only a fragment of an nginx config plus the Elastic Beanstalk headers).
+* config.logger.logDirectory - the location of the log file for the server. The default is the current working directory, and the default location + name are set up in the [cloud-log-init.config](https://github.com/smart-facility/cognicity-server/blob/master/.ebextensions/cloud-log-init.config) file for easy export of the log file in Elastic Beanstalk.
 
 #### API
 * aggregates.archive.level - The key of the aggregate level ('config.pg.aggregate_levels') to use for archive aggregate response data

--- a/config.js
+++ b/config.js
@@ -101,7 +101,7 @@ config.logger = {};
 config.logger.level = "debug"; // What level to log at; info, verbose or debug are most useful. Levels are (npm defaults): silly, debug, verbose, info, warn, error.
 config.logger.maxFileSize = 1024 * 1024 * 100; // Max file size in bytes of each log file; default 100MB
 config.logger.maxFiles = 10; // Max number of log files kept
-config.logger.logDirectory = '/var/log/nodejs'; // Set this to a full path to a directory - if not set logs will be written to the application directory.
+config.logger.logDirectory = '.'; // Set this to a full path to a directory - if not set logs will be written to the application directory.
 
 // Server port
 config.port = process.env.PORT || 8081;


### PR DESCRIPTION
Fixes #15.

Sample log output (after getting EB to copy logs to S3):

-------------------------------------
/var/app/current/cognicity-server.log
-------------------------------------
2015-10-14T00:42:02.886Z - info: Application starting, listening on port 8081
2015-10-14T00:42:09.656Z - debug: Parsed option 'tbl' as 'jkt_subdistrict_boundary'
2015-10-14T00:42:09.656Z - debug: Parsed option 'hours' as '1'
2015-10-14T00:42:09.657Z - debug: dataQuery: queryObject={"text":"SELECT 'FeatureCollection' AS type, array_to_json(array_agg(f)) AS features FROM (SELECT 'Feature' AS type, ST_AsGeoJSON(lg.the_geom)::json As geometry,row_to_json( (SELECT l FROM (SELECT lg.pkey, lg.area_name as level_name, lg.sum_count as count ) AS l ) ) AS properties FROM ( SELECT c1.pkey, c1.area_name, c1.the_geom, c1.count+c2.count sum_count FROM ( SELECT p1.pkey, p1.area_name, p1.the_geom, COALESCE(count.count,0) count FROM jkt_subdistrict_boundary AS p1 LEFT OUTER JOIN ( SELECT b.pkey, count(a.pkey) FROM tweet_reports_unconfirmed a, jkt_subdistrict_boundary b WHERE ST_WITHIN(a.the_geom, b.the_geom) AND a.created_at >=to_timestamp($1) AND a.created_at <= to_timestamp($2) GROUP BY b.pkey ) as count ON (p1.pkey = count.pkey) ) as c1, ( SELECT p1.pkey, COALESCE(count.count,0) count  FROM jkt_subdistrict_boundary AS p1 LEFT OUTER JOIN( SELECT b.pkey, count(a.pkey) FROM tweet_reports a, jkt_subdistrict_boundary b WHERE ST_WITHIN(a.the_geom, b.the_geom) AND a.created_at >= to_timestamp($1) AND a.created_at < to_timestamp($2) GROUP BY b.pkey) as count ON (p1.pkey = count.pkey) ) as c2 WHERE c1.pkey=c2.pkey ORDER BY pkey ) AS lg ) AS f;","values":[1444779729,1444783329]}
2015-10-14T00:42:09.837Z - debug: dataQuery: 1 rows returned
2015-10-14T00:42:09.901Z - info: ::ffff:127.0.0.1 - - [14/Oct/2015:00:42:09 +0000] "GET /banjir/data/api/v1/aggregates/live?format=topojson&level=subdistrict&hours=1 HTTP/1.1" 200 - "-" "ELB-HealthChecker/1.0"