### PR TITLE
Api redirect

### DIFF
--- a/server.js
+++ b/server.js
@@ -145,7 +145,8 @@ if (config.data === true){
 
 	// Depreciate data API v1
 	app.get('/'+config.url_prefix+'/data/api/v1*',function(req, res, next){
-		res.redirect(303, '/'+config.url_prefix+'/data/api/v2'+req.params[0]);
+		res.redirect(301, '/'+config.url_prefix+'/data/api/v2'+req.params[0]);
+		res.setHeader('Cache-Control','max-age=60');
 	});
 
 	app.get( new RegExp('/'+config.url_prefix+'/data/api/v2/.*'), function(req, res, next){

--- a/server.js
+++ b/server.js
@@ -145,8 +145,8 @@ if (config.data === true){
 
 	// Depreciate data API v1
 	app.get('/'+config.url_prefix+'/data/api/v1*',function(req, res, next){
-		res.redirect(301, '/'+config.url_prefix+'/data/api/v2'+req.params[0]);
 		res.setHeader('Cache-Control','max-age=60');
+		res.redirect(301, '/'+config.url_prefix+'/data/api/v2'+req.params[0]);
 	});
 
 	app.get( new RegExp('/'+config.url_prefix+'/data/api/v2/.*'), function(req, res, next){


### PR DESCRIPTION
Fixes #22. @talltom please test. Note if you've ever run 6785be6 you will need to clear your browser cache. My initial go had an error which wasn't exposed in my initial test as I had another bug that meant the order of the two calls to res.setHeader and res.redirect in code got swapped at runtime. e28bf1f has fixed the other bug and therefore runs correctly to fix #22.

Headers you should see on calling GET /banjir/data/api/v1/reports/confirmed are:
Access-Control-Allow-Headers:X-Requested-With
Access-Control-Allow-Origin:*
Cache-Control:max-age=60
Content-Length:130
Content-Type:text/html; charset=utf-8
Date:Thu, 29 Oct 2015 02:35:57 GMT
Location:/banjir/data/api/v2/reports/confirmed
Vary:Accept
X-Powered-By:Express