### PR TITLE
fixed floodwatch api when options.limit not set in config

### DIFF
--- a/CognicityServer.js
+++ b/CognicityServer.js
@@ -226,7 +226,7 @@ CognicityServer.prototype = {
 
 		// Set default values
 		if ( !options.limit ) {
-			options.limit = 'ALL';
+			options.limit = null;
 		}
 
 		// SQL


### PR DESCRIPTION
@matthewberryman petajakarta.org/banjir/data/api/v2/floodwatch/reports currently returns a 204 if options.limit is not set in config.
